### PR TITLE
feat: mark python doc pseudo-code blocks with a tag

### DIFF
--- a/mathy_pydoc/loader.py
+++ b/mathy_pydoc/loader.py
@@ -119,7 +119,7 @@ class PythonLoader(object):
             sig, fn_type = get_function_signature(
                 obj, scope if inspect.isclass(scope) else None
             )
-            section.content = f"```python\n{sig}\n```\n{section.content}"
+            section.content = f"```python (doc)\n{sig}\n```\n{section.content}"
             section.title = f"{section.title} <kbd>{fn_type}</kbd>"
 
 


### PR DESCRIPTION
 - if you're looking at ```python blocks in a file, it can be easy to end up thinking these doc blocs represent runnable code, when in fact they're just pseudocode that looks nice with syntax highlighting.